### PR TITLE
Update actions/update-python to v5 (latest)

### DIFF
--- a/.github/workflows/LocusPocus.yml
+++ b/.github/workflows/LocusPocus.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install


### PR DESCRIPTION
With v1 there is a build warning:
```
build (3.12)
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-python@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

E.g. see https://github.com/martin-g/AEGeAn/actions/runs/7542984733